### PR TITLE
feat: add upload progress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Also, you might want to get your storage account key in azure portal, and put it
 - `account`: The azure storage account name
 - `container`: The container in provided azure storage
 - `directory`: The directory containing your files to upload to azure storage container.
+- `progress`: If true, show upload progress.
 
 This workflow will `readdir` to your input `directory`, and it will upload all the file with its original name to the azure storage container. It will skip the directory inside the directory. So, no nested upload supported now.
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   directory:
     description: 'The directory to upload. It will list file recursively in this diectionary and upload to azure storage blob'
     required: true
+  progress:
+    description: 'Show upload progress'
+    required: false
+    default: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -19308,7 +19308,7 @@ var require_core = __commonJS({
     }
     __name(getMultilineInput, "getMultilineInput");
     exports2.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput2(name, options);
@@ -19319,8 +19319,8 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    __name(getBooleanInput, "getBooleanInput");
-    exports2.getBooleanInput = getBooleanInput;
+    __name(getBooleanInput2, "getBooleanInput");
+    exports2.getBooleanInput = getBooleanInput2;
     function setOutput(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -78186,6 +78186,7 @@ async function run() {
     const account = (0, import_core.getInput)("account", { required: true });
     const container = (0, import_core.getInput)("container", { required: true });
     const dir = (0, import_core.getInput)("directory", { required: true });
+    const progress = (0, import_core.getBooleanInput)("progress");
     const accountKey = process.env.AZURE_ACCOUNT_KEY;
     let credit;
     if (typeof accountKey === "string") {
@@ -78203,7 +78204,10 @@ async function run() {
       }
       const fileStat = await (0, import_promises.stat)(filePath);
       const options = {
-        blobHTTPHeaders: {}
+        blobHTTPHeaders: {},
+        onProgress: progress ? (progress2) => {
+          (0, import_core.info)(`-> ${progress2.loadedBytes} / ${fileStat.size} bytes`);
+        } : void 0
       };
       if (relativePath.endsWith("yml")) {
         options.blobHTTPHeaders.blobContentType = "text/x-yaml";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getInput, info, setFailed } from '@actions/core';
+import { getBooleanInput, getInput, info, setFailed } from '@actions/core';
 import { AnonymousCredential, BlockBlobClient, BlockBlobUploadOptions, StorageSharedKeyCredential } from '@azure/storage-blob';
 import { createReadStream } from 'fs';
 import { readdir, stat } from "fs/promises";
@@ -26,6 +26,7 @@ async function run() {
     const account = getInput('account', { required: true });
     const container = getInput('container', { required: true });
     const dir = getInput('directory', { required: true });
+    const progress = getBooleanInput('progress');
 
     const accountKey = process.env.AZURE_ACCOUNT_KEY;
 
@@ -49,6 +50,9 @@ async function run() {
       const options: BlockBlobUploadOptions = {
         blobHTTPHeaders: {
         },
+        onProgress: progress ? (progress) => {
+          info(`-> ${progress.loadedBytes} / ${fileStat.size} bytes`);
+        } : undefined,
       };
       if (relativePath.endsWith("yml")) { // if the file is the yml file use yml format
         options.blobHTTPHeaders!.blobContentType = 'text/x-yaml';


### PR DESCRIPTION
I tested this feature just now and it works fine. Example output:

```console
> Run ...
Found and use SharedKeyCredential (accountKey)
Upload ...
Upload ...
Upload ...
-> 29 / 29 bytes
-> 65536 / 2798143 bytes
...
-> 2752512 / 2798143 bytes
-> 2798143 / 2798143 bytes

```

Built with node v18.20.8 and pnpm 7.33.7.